### PR TITLE
Implement API endpoints for exchange rates and currency conversion

### DIFF
--- a/src/main/java/com/forexapp/forexapplication/controller/ExchangeRateController.java
+++ b/src/main/java/com/forexapp/forexapplication/controller/ExchangeRateController.java
@@ -1,9 +1,6 @@
 package com.forexapp.forexapplication.controller;
 
-import com.forexapp.forexapplication.dto.ConversionHistoryRequest;
-import com.forexapp.forexapplication.dto.ConversionHistoryResponse;
-import com.forexapp.forexapplication.dto.CurrencyConversionRequest;
-import com.forexapp.forexapplication.dto.CurrencyConversionResponse;
+import com.forexapp.forexapplication.dto.*;
 import com.forexapp.forexapplication.exception.InternalCustomException;
 import com.forexapp.forexapplication.response.ErrorCodes;
 import com.forexapp.forexapplication.response.ResponseWrapper;
@@ -71,6 +68,40 @@ public class ExchangeRateController {
             List<ConversionHistoryResponse> history = currencyConversionService.getConversionHistory(request);
 
             return ResponseEntity.ok(ResponseWrapper.ok(history));
+        } catch (InternalCustomException e) {
+            logger.error(e.getMessage(), e);
+
+            return ResponseEntity.ok(ResponseWrapper.error(e.getErrorCode(), e.getErrorArguments()));
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseWrapper.error(ErrorCodes.ERRORS_GENERAL_ERROR, null));
+        }
+    }
+
+    @GetMapping("/api/exchange-rates")
+    public ResponseEntity<?> getExchangeRates(@RequestParam String baseCurrency) {
+        try {
+            ExchangeRateResponse response = exchangeRateService.getExchangeRates(baseCurrency);
+            return ResponseEntity.ok(ResponseWrapper.ok(response));
+        } catch (InternalCustomException e) {
+            logger.error(e.getMessage(), e);
+
+            return ResponseEntity.ok(ResponseWrapper.error(e.getErrorCode(), e.getErrorArguments()));
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ResponseWrapper.error(ErrorCodes.ERRORS_GENERAL_ERROR, null));
+        }
+    }
+
+    @PostMapping("/api/exchange-convert")
+    public ResponseEntity<?> convertCurrency(@RequestBody ExchangeRateRequest request) {
+        try {
+            double response = exchangeRateService.convertCurrency(request);
+           return ResponseEntity.ok(ResponseWrapper.ok(response));
         } catch (InternalCustomException e) {
             logger.error(e.getMessage(), e);
 

--- a/src/main/java/com/forexapp/forexapplication/dto/ExchangeRateRequest.java
+++ b/src/main/java/com/forexapp/forexapplication/dto/ExchangeRateRequest.java
@@ -1,0 +1,10 @@
+package com.forexapp.forexapplication.dto;
+
+import lombok.Data;
+
+@Data
+public class ExchangeRateRequest {
+    private String fromCurrency;
+    private String toCurrency;
+    private double amount;
+}

--- a/src/main/java/com/forexapp/forexapplication/dto/ExchangeRateResponse.java
+++ b/src/main/java/com/forexapp/forexapplication/dto/ExchangeRateResponse.java
@@ -1,0 +1,12 @@
+package com.forexapp.forexapplication.dto;
+
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+public class ExchangeRateResponse {
+    private String base;
+    private String date;
+    private Map<String, Double> rates;
+}

--- a/src/main/java/com/forexapp/forexapplication/response/ErrorCodes.java
+++ b/src/main/java/com/forexapp/forexapplication/response/ErrorCodes.java
@@ -5,7 +5,9 @@ public class ErrorCodes {
     public static final String ERRORS_INVALID_API_RESPONSE= "Invalid API response for exchange rates.";
     public static final String ERRORS_RATE_NOT_FOUND= "Exchange rate for target currency not found.";
     public static final String ERRORS_CURRENCY_NOT_SUPPORTED= "Currency is not supported";
-    public static final String ERRORS_GENERAL_ERROR= "ERRORS_GENERAL_ERROR";
-    public static final String ERRORS_TRANSACTION_ID_NULL= "ERRORS_TRANSACTION_ID_NULL";
+    public static final String ERRORS_GENERAL_ERROR= "Error general.";
+    public static final String ERRORS_TRANSACTION_ID_NULL= "Transaction is null.";
+    public static final String ERRORS_UNEXPECTED_RATE_TYPE= "Unexpected rate type.";
+    public static final String ERRORS_INVALID_TARGET_CURRENCY= "Invalid target currency.";
 
 }

--- a/src/test/java/com/forexapp/forexapplication/ExchangeRateServiceMockTest.java
+++ b/src/test/java/com/forexapp/forexapplication/ExchangeRateServiceMockTest.java
@@ -1,0 +1,45 @@
+package com.forexapp.forexapplication;
+
+import com.forexapp.forexapplication.dto.ExchangeRateRequest;
+import com.forexapp.forexapplication.dto.ExchangeRateResponse;
+import com.forexapp.forexapplication.service.ExchangeRateService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+public class ExchangeRateServiceMockTest {
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private ExchangeRateService exchangeRateService;
+
+    @Test
+    public void testConvertCurrency() {
+        ExchangeRateResponse mockResponse = new ExchangeRateResponse();
+        mockResponse.setBase("USD");
+        HashMap<String, Double> rates = new HashMap<>();
+        rates.put("EUR", 0.85);
+        mockResponse.setRates(rates);
+
+        when(restTemplate.getForObject("https://api.exchangerate-api.com/v4/latest/USD", ExchangeRateResponse.class, "USD"))
+                .thenReturn(mockResponse);
+
+        ExchangeRateRequest request = new ExchangeRateRequest();
+        request.setFromCurrency("USD");
+        request.setToCurrency("EUR");
+        request.setAmount(100);
+
+        double result = exchangeRateService.convertCurrency(request);
+        assertEquals(96.1, result, 0.001);
+    }
+}


### PR DESCRIPTION
- Added GET /api/exchange-rates to retrieve exchange rates for a given base currency.
- Added POST /api/exchange-convert to convert an amount from one currency to another.